### PR TITLE
Refactoring to get ready for A2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ COMP 360 ON1 Assignments
 ## A2: Interactive Driving Simulation
 
 ## A1: 3D Landscape
-Completed October 2, 2025
-[Contributions Document](\a1-3d-landscape\README.md)
+Completed October 2, 2025 - 
+[Contributions Document](a1-3d-landscape/README.md)
 
 

--- a/README.md
+++ b/README.md
@@ -1,43 +1,9 @@
 COMP 360 ON1 Assignments
 
+## A2: Interactive Driving Simulation
 
-## Assignment 1: 3D Landscape
+## A1: 3D Landscape
+Completed October 2, 2025
+[Contributions Document](\a1-3d-landscape\README.md)
 
-#### Generate 3D landscape
-- Sunny Pak
-- Aniket Sandhu
-- William Craske
-- Pragti Duggal
-- Ayush Jain
-- Sho Okano
 
-#### Generate 2D texture
-- Sho Okano
-- William Craske
-- Fahim Ar-Rashid
-
-#### Document debugging/testing with video or wiki
-- Sho Okano, [Initial 2D Texture Creation (video)](https://youtu.be/Hb5TNBVI_qE), [With texture overlay vs without (wiki page)](https://github.com/360-g5/assignments/wiki/With-texture-overlay-vs-without)
-- William Craske, [2D fix and 3D base Creation (video)](https://www.youtube.com/watch?v=Jn8QvWzMxn8)
-- Sunny Pak, [How Sunny Approached This (wiki page)](https://github.com/360-g5/assignments/wiki/How-Sunny-Approached-This)
-- Aniket Sandhu, [How Aniket Approached This (wiki page)](https://github.com/360-g5/assignments/wiki/How-Aniket-Approached-This)
-- Ayush Jain, [How Ayush Jain Approached This (Wiki Page) ](https://github.com/360-g5/assignments/wiki/How-Ayush-Jain-Approached-This)
-
-#### Test & review pull requests
-- Pragti Duggal
-- Sho Okano
-- Ayush Jain
-  
-#### Update project documentation (README.md, kanban board)
-- Sho Okano
-- William Craske
-- Aniket Sandhu
-- Sunny Pak
-- Pragti Duggal
-- Ayush Jain
-
-#### Update discord documentation (meeting minutes, assignment clarifications, helpful tools) 
-- Sho Okano
-- Fahim Ar-Rashid
-- Aniket Sandhu
-- Ayush Jain

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 COMP 360 ON1 Assignments
 
 ## A2: Interactive Driving Simulation
+Due October 30, 2025 - [Contributions Document](a2-driving-sim/README.md)
 
 ## A1: 3D Landscape
-Completed October 2, 2025 - 
-[Contributions Document](a1-3d-landscape/README.md)
+Completed October 2, 2025 - [Contributions Document](a1-3d-landscape/README.md)
 
 

--- a/a1-3d-landscape/README.md
+++ b/a1-3d-landscape/README.md
@@ -1,0 +1,43 @@
+COMP 360 ON1 Assignments
+
+
+## Assignment 1: 3D Landscape
+
+#### Generate 3D landscape
+- Sunny Pak
+- Aniket Sandhu
+- William Craske
+- Pragti Duggal
+- Ayush Jain
+- Sho Okano
+
+#### Generate 2D texture
+- Sho Okano
+- William Craske
+- Fahim Ar-Rashid
+
+#### Document debugging/testing with video or wiki
+- Sho Okano, [Initial 2D Texture Creation (video)](https://youtu.be/Hb5TNBVI_qE), [With texture overlay vs without (wiki page)](https://github.com/360-g5/assignments/wiki/With-texture-overlay-vs-without)
+- William Craske, [2D fix and 3D base Creation (video)](https://www.youtube.com/watch?v=Jn8QvWzMxn8)
+- Sunny Pak, [How Sunny Approached This (wiki page)](https://github.com/360-g5/assignments/wiki/How-Sunny-Approached-This)
+- Aniket Sandhu, [How Aniket Approached This (wiki page)](https://github.com/360-g5/assignments/wiki/How-Aniket-Approached-This)
+- Ayush Jain, [How Ayush Jain Approached This (Wiki Page) ](https://github.com/360-g5/assignments/wiki/How-Ayush-Jain-Approached-This)
+
+#### Test & review pull requests
+- Pragti Duggal
+- Sho Okano
+- Ayush Jain
+  
+#### Update project documentation (README.md, kanban board)
+- Sho Okano
+- William Craske
+- Aniket Sandhu
+- Sunny Pak
+- Pragti Duggal
+- Ayush Jain
+
+#### Update discord documentation (meeting minutes, assignment clarifications, helpful tools) 
+- Sho Okano
+- Fahim Ar-Rashid
+- Aniket Sandhu
+- Ayush Jain

--- a/a1-3d-landscape/TerrainGenerator.gd
+++ b/a1-3d-landscape/TerrainGenerator.gd
@@ -1,3 +1,4 @@
+@tool
 extends Node
 
 class_name TerrainGenerator

--- a/a1-3d-landscape/TerrainGenerator.gd
+++ b/a1-3d-landscape/TerrainGenerator.gd
@@ -2,6 +2,23 @@ extends Node
 
 class_name TerrainGenerator
 
+# Exports for heightmap
+@export_group("Heightmap Noise")
+@export var height_seed: int = 654
+@export var height_freq: float = 0.0158
+@export var height_lacunarity: float = 0.5
+@export var height_gain: float = 0.5
+
+# Exports for texture
+@export_group("Texture Noise")
+@export var texture_seed: int = 654
+@export var texture_freq: float = 0.2158  # adjusted, original A1 setting below
+#@export var texture_freq: float = 0.0158
+@export var texture_lacunarity: float = 2.5  # adjusted, original A1 setting below
+#@export var texture_lacunarity: float = 0.5
+@export var texture_gain: float = 22.5  # adjusted, original A1 setting below
+#@export var texture_gain: float = 0.5
+
 # Exported so you can tweak from the editor later
 @export var grid_scale: float = 1.0
 @export var height_scale: float = 40.0
@@ -10,7 +27,11 @@ class_name TerrainGenerator
 
 var terrain: MeshInstance3D
 
-func make_noise(noise_seed: int = 654, freq = 0.0158, lacuna: float = 0.5, gain: float = 0.5) -> FastNoiseLite:
+# called from generate_mesh() and _make_noise_texture_2d()
+func _make_noise(noise_seed: int, freq: float, lacuna: float, gain: float) -> FastNoiseLite:
+	"""
+	Creates noise image used for mesh and texture
+	"""
 	var noise := FastNoiseLite.new()
 	noise.seed = noise_seed
 	noise.noise_type = FastNoiseLite.TYPE_PERLIN
@@ -22,32 +43,22 @@ func make_noise(noise_seed: int = 654, freq = 0.0158, lacuna: float = 0.5, gain:
 	noise.fractal_weighted_strength = 0.5
 	return noise
 
-func generate_texture():
-	var noise_texture = await make_noise_texture()
-	var material = noise_texture_to_material(noise_texture)
-	return material
-
-func make_noise_texture() -> NoiseTexture2D:
-	var noise_texture = NoiseTexture2D.new()
-	noise_texture.noise = make_noise()
-	await noise_texture.changed
-	noise_texture.width = width
-	noise_texture.height = height
-	return noise_texture
-	
-func noise_texture_to_material(noise_texture: NoiseTexture2D) -> StandardMaterial3D:
-	var material = StandardMaterial3D.new()
-	material.albedo_texture = noise_texture
-	return material
-	
-
+# called from main.gd > _setup_scene()
 func generate_mesh() -> MeshInstance3D:
-	var noise := make_noise()
+	"""
+	Returns a MeshInstance3D created from an image
+	generated using exported heightmap settings
+	"""
+	var noise := _make_noise(height_seed, height_freq, height_lacunarity, height_gain)
 	var img := noise.get_image(width, height)
 	return _image_to_mesh(img)
 
-
+# called from generate_mesh()
 func _image_to_mesh(image: Image) -> MeshInstance3D:
+	"""
+	Converts image (ie heightmap) into MeshInstance3D
+	value of a given pixel determines height of vertex at that point
+	"""
 	var w := image.get_width()
 	var h := image.get_height()
 	var st := SurfaceTool.new()
@@ -80,3 +91,36 @@ func _image_to_mesh(image: Image) -> MeshInstance3D:
 	var mi := MeshInstance3D.new()
 	mi.mesh = mesh
 	return mi
+
+# called from generate_texture()
+func _make_noise_texture_2d() -> NoiseTexture2D:
+	"""
+	Creates the NoiseTexture2D to be used for the 
+	StandardMaterial3D overlaid on the mesh
+	"""
+	var noise_texture = NoiseTexture2D.new()
+	noise_texture.noise = _make_noise(texture_seed, texture_freq, texture_lacunarity, texture_gain)
+	await noise_texture.changed
+	noise_texture.width = width
+	noise_texture.height = height
+	return noise_texture
+	
+# called from generate_texture()
+func _noise_texture_2d_to_material(noise_texture: NoiseTexture2D) -> StandardMaterial3D:
+	"""
+	Creates StandardMaterial3D to be displayed on mesh from provided 
+	NoiseTexture2D
+	"""
+	var material = StandardMaterial3D.new()
+	material.albedo_texture = noise_texture
+	return material
+	
+# called from main.gd > _setup_scene()
+func generate_texture():
+	"""
+	Returns a StandardMaterial3D (made from NoiseTexture2D)
+	to be used on mesh surface
+	"""
+	var noise_texture = await _make_noise_texture_2d()
+	var material = _noise_texture_2d_to_material(noise_texture)
+	return material

--- a/a1-3d-landscape/landscape.tscn
+++ b/a1-3d-landscape/landscape.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://jmn4kqdlwldf"]
+
+[ext_resource type="Script" uid="uid://1jd4srtniam3" path="res://main.gd" id="1_8vpcf"]
+
+[node name="Landscape" type="Node3D"]
+script = ExtResource("1_8vpcf")

--- a/a1-3d-landscape/main.gd
+++ b/a1-3d-landscape/main.gd
@@ -2,6 +2,9 @@ extends Node3D
 @onready var terrain_generator := TerrainGenerator.new()
 
 func _ready():
+	_setup_scene()
+	
+func _setup_scene():
 	# Terrain
 	var terrain := terrain_generator.generate_mesh()
 	var texture = await terrain_generator.generate_texture()
@@ -9,8 +12,8 @@ func _ready():
 	add_child(terrain)
 
 	# Camera
-	add_child(make_camera(Vector3(264, 60, 460), Vector3(64, 0, 64)))
-
+	add_child(make_camera(Vector3(251, 60, 460), Vector3(251, 0, 64))) 
+	
 	# Lighting
 	add_child(make_sun())
 
@@ -18,7 +21,7 @@ func _ready():
 func make_camera(pos: Vector3, target: Vector3) -> Camera3D:
 	var camera := Camera3D.new()
 	camera.position = pos
-	camera.look_at(target, Vector3.UP)
+	camera.look_at_from_position(pos, target, Vector3.UP) 
 	camera.current = true
 	return camera
 

--- a/a1-3d-landscape/main.gd
+++ b/a1-3d-landscape/main.gd
@@ -1,11 +1,12 @@
+@tool
 extends Node3D
-@onready var terrain_generator := TerrainGenerator.new()
 
 func _ready():
 	_setup_scene()
 	
 func _setup_scene():
 	# Terrain
+	var terrain_generator := TerrainGenerator.new()
 	var terrain := terrain_generator.generate_mesh()
 	var texture = await terrain_generator.generate_texture()
 	terrain.set_surface_override_material(0, texture)

--- a/a1-3d-landscape/node_3d.tscn
+++ b/a1-3d-landscape/node_3d.tscn
@@ -1,6 +1,7 @@
 [gd_scene load_steps=2 format=3 uid="uid://btv7qx4ar2y31"]
 
-[ext_resource type="Script" uid="uid://1jd4srtniam3" path="res://main.gd" id="1_a202f"]
+[ext_resource type="PackedScene" uid="uid://jmn4kqdlwldf" path="res://landscape.tscn" id="1_a202f"]
 
-[node name="Node3D" type="Node3D"]
-script = ExtResource("1_a202f")
+[node name="World" type="Node3D"]
+
+[node name="Landscape" parent="." instance=ExtResource("1_a202f")]

--- a/a2-driving-sim/README.md
+++ b/a2-driving-sim/README.md
@@ -1,0 +1,35 @@
+COMP 360 ON1 Assignments
+
+
+## Assignment 2: Interactive Driving Simulation
+
+#### Generate core track
+- TBD
+
+#### Camera & driving controls
+- TBD
+
+#### Feature: 
+- TBD
+
+#### Feature: 
+- TBD
+
+#### Feature: 
+- TBD
+
+#### Feature: 
+- TBD
+
+#### Feature: 
+- TBD
+
+#### Document debugging/testing with video or wiki
+- TBD
+
+#### Test & review pull requests
+- TBD
+
+#### Update project documentation (README.md, kanban board, discord)
+- TBD
+


### PR DESCRIPTION
Based on instructor feedback about unclear use of noise parameters, noise settings for heightmap and texture are separated and set as exported variables in TerrainGenerator.gd

Also adjusted texture noise parameter values to experiment with grainier look. Original settings are commented out beneath changed lines.

Add more comments and documentation strings to TerrainGenerator.gd

make_camera() now uses look_at_from_position() to resolve "Node not inside tree. Use look_at_from_position() instead" error. Adjusted Vector3s passed to make_camera() to mimic camera position from look_at()

Based on instructor feedback, moved A1 README.md containing that assignment's contributions list to the A1 project directory. Root-level README.md will now link to individual project contributions lists.

Use @tool to make landscape show in godot editor panel.

Separate Landscape into its own node and scene.